### PR TITLE
add handling for new+old vm service responses

### DIFF
--- a/ui/src/components/ContainersGrid.tsx
+++ b/ui/src/components/ContainersGrid.tsx
@@ -379,10 +379,16 @@ export default function ContainersGrid() {
         metadata: config.metadata,
       });
 
+      // Handle both old and new response structures (Docker Desktop API change)
+      const endpointData = response.data?.endpoint || response.endpoint;
+      if (!endpointData || !endpointData.url) {
+        throw new Error(`Unexpected response from create_endpoint: ${JSON.stringify(response)}`);
+      }
+
       // Add to running endpoints
       const runningEndpoint: RunningEndpoint = {
         id: container.id,
-        url: response.endpoint.url,
+        url: endpointData.url,
         containerId: container.ContainerId,
         targetPort: container.Port.PublicPort.toString()
       };
@@ -392,7 +398,7 @@ export default function ContainersGrid() {
       statusService.checkStatusNow();
 
       ddClient.desktopUI.toast.success(
-        `Endpoint started at ${response.endpoint.url}`
+        `Endpoint started at ${endpointData.url}`
       );
     } catch (error: any) {
       console.log(error);

--- a/ui/src/components/EndpointConfigurationDialog.tsx
+++ b/ui/src/components/EndpointConfigurationDialog.tsx
@@ -106,7 +106,11 @@ export default function EndpointConfigurationDialog({
       };
       
       ddClient.extension.vm?.service?.post('/detect_protocol', request)
-        .then((result) => setProtocolDetection(result as DetectProtocolResponse))
+        .then((result: any) => {
+          // Handle both old and new response structures (Docker Desktop API change)
+          const responseData = result?.data || result;
+          setProtocolDetection(responseData as DetectProtocolResponse);
+        })
         .catch(() => setProtocolDetection({
           tcp: false,
           http: false,

--- a/ui/src/services/statusService.ts
+++ b/ui/src/services/statusService.ts
@@ -41,12 +41,14 @@ export class StatusService {
     try {
       const result = await ddClient.extension.vm?.service?.get('/agent_status') as any;
       
-      if (result) {
+      // Handle both old and new response structures (Docker Desktop API change)
+      const statusData = result?.data || result;
+      if (statusData) {
         const status: AgentStatus = {
-          status: result.status,
-          timestamp: result.timestamp,
-          connectionLatency: result.connectionLatency,
-          lastError: result.lastError
+          status: statusData.status,
+          timestamp: statusData.timestamp,
+          connectionLatency: statusData.connectionLatency,
+          lastError: statusData.lastError
         };
         this.onStatusUpdate?.(status);
       } else {


### PR DESCRIPTION
Several of us who were testing the extension could no longer use it effectively because there was a change after updating docker-desktop. The responses for the requests made to the VM service seem to now be wrapped in a `data: {}` field. This adds handling for both the new and old formats and adds a couple new thrown errors for cases where the responses still don't fit either format.