### PR TITLE
Update installation instructions, provide direct link to Docker Hub marketplace

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ Go here if you're looking for the [ngrok Docker image](#docker-image).
 
 To install the extension:
 
-1. Open Docker Desktop and go to the extensions marketplace.
-2. Search for "ngrok" and click "Install".
-3. Once installed, activate the extension by clicking on the ngrok icon in the Docker Desktop toolbar.
+1. Navigate to Docker Hub → [ngrok/ngrok-docker-extension](https://hub.docker.com/r/ngrok/ngrok-docker-extension)
+2. In the Tag drop-down menu, select the extension version you wish to install. We recommend using the latest available version.
+3. Click `Run in Docker Desktop`
 
 ## Quick start
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ To install the extension:
 After installing the extension:
 
 1. The extension will prompt you to add your ngrok authtoken
-2. Start an endpoint by clicking the start icon on the container you want to put online
+2. Start an endpoint by clicking the `+` icon on the container you want to put online
 3. Optionally specify a custom URL and [traffic policy](https://ngrok.com/docs/traffic-policy/).
 4. You have an endpoint URL for your container that you can share!
 


### PR DESCRIPTION
There's lots of results for `"ngrok"` in the app marketplace - [hopefully?] repacks of our agent.

This PR updates the `README` to link directly to our store enlistment, thereby ensuring users get the official/latest version of the extension.

<img width="726" height="1071" alt="image" src="https://github.com/user-attachments/assets/5e5d9813-3b1e-4370-9ee3-45597eb4d13b" />
