### PR TITLE
set build arg version to tag value when publishing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ prepare-buildx: ## Create buildx builder for multi-arch build, if not exists
 	docker buildx inspect $(BUILDER) || docker buildx create --name=$(BUILDER) --driver=docker-container --driver-opt=network=host
 
 push-extension: prepare-buildx ## Build & Upload extension image to hub. Do not push if tag already exists: make push-extension tag=0.1
-	docker buildx build --push --builder=$(BUILDER) --platform=linux/amd64,linux/arm64 --build-arg TAG=$(TAG) --tag=$(IMAGE):$(TAG) .
+	docker buildx build --push --builder=$(BUILDER) --platform=linux/amd64,linux/arm64 --build-arg VERSION=$(TAG) --tag=$(IMAGE):$(TAG) .
 
 help: ## Show this help
 	@echo Please specify a build target. The choices are:


### PR DESCRIPTION
this will make sure the pushed tag version is always in sync with the reported extension version