### PR TITLE
fix: add qemu and fix release multiarch

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,11 +27,14 @@ jobs:
         with:
           go-version-file: backend/go.mod
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - id: buildx-setup
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
-          platforms: linux/amd64
+          platforms: ${{ env.DOCKER_BUILDX_PLATFORMS }}
 
       - name: Fetch git tag
         id: git-tag


### PR DESCRIPTION
release workflow was missing qemu and buildx was only setup for linux/amd64